### PR TITLE
Added ability to pass step amount for minutes value

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{js,jsx}'],
   testMatch: ['<rootDir>/test/*.test.js'],
   bail: true,
-  verbose: false
+  verbose: false,
+  testURL: 'http://localhost/'
 };

--- a/src/TimeInput.js
+++ b/src/TimeInput.js
@@ -87,16 +87,36 @@ var TimeInput = CreateReactClass({
     if (this.props.value.charAt(index) === ' ') index++;
     if (this.mounted) this.setState({ caretIndex: index });
   },
-  handleArrows(event) {
-    event.preventDefault();
-    var start = caret.start(this.input);
-    var value = this.props.value;
-    var amount = event.which === 38 ? 1 : -1;
+  getStep() {
+    var step = this.props.step;
+    if (typeof step === 'number') {
+      return step;
+    } else {
+      return 1;
+    }
+  },
+  getAmount(event, groupId) {
+    var amount = 1;
+    if (groupId === 1) {
+      amount = this.getStep();
+    }
     if (event.shiftKey) {
       amount *= 2;
       if (event.metaKey) amount *= 2;
     }
-    value = adder(value, getGroupId(start), amount);
+    if (event.which === 38) {
+      return amount;
+    } else {
+      return -amount;
+    }
+  },
+  handleArrows(event) {
+    event.preventDefault();
+    var start = caret.start(this.input);
+    var value = this.props.value;
+    var groupId = getGroupId(start);
+    var amount = this.getAmount(event, groupId);
+    value = adder(value, groupId, amount);
     this.onChange(value, start);
   },
   silhouette() {

--- a/test/arrow-keys.test.js
+++ b/test/arrow-keys.test.js
@@ -65,6 +65,18 @@ describe('up', function() {
       '01:00:00:000 AM'
     );
   });
+  it('should increment minutes with given step amount', function() {
+    expect(arrow('01:00 AM', 3, true, false, false, 15).input.value).toEqual('01:15 AM');
+    expect(arrow('01:00:00:000 PM', 3, true, false, false, 15).input.value).toEqual(
+      '01:15:00:000 PM'
+    );
+  });
+  it('should increment hours with given step for minutes amount', function() {
+    expect(arrow('01:45 AM', 3, true, false, false, 15).input.value).toEqual('02:00 AM');
+    expect(arrow('01:45:00:000 PM', 3, true, false, false, 15).input.value).toEqual(
+      '02:00:00:000 PM'
+    );
+  });
 });
 
 describe('down', function() {
@@ -129,11 +141,23 @@ describe('down', function() {
       '01:00:00:000 AM'
     );
   });
+  it('should decrement minutes with given step amount', function() {
+    expect(arrow('01:30 AM', 3, false, false, false, 15).input.value).toEqual('01:15 AM');
+    expect(arrow('01:30:00:000 PM', 3, false, false, false, 15).input.value).toEqual(
+      '01:15:00:000 PM'
+    );
+  });
+  it('should decrement hours with given step for minutes amount', function() {
+    expect(arrow('01:00 AM', 3, false, false, false, 15).input.value).toEqual('12:45 AM');
+    expect(arrow('01:00:00:000 PM', 3, false, false, false, 15).input.value).toEqual(
+      '12:45:00:000 PM'
+    );
+  });
 });
 
-function arrow(value, caretIndex, up, shiftKey, metaKey) {
+function arrow(value, caretIndex, up, shiftKey, metaKey, step) {
   document.body.innerHTML = '<div></div>';
-  var timeInput = render(value);
+  var timeInput = render(value, null, false, step);
   caret.set(timeInput.input, caretIndex);
   ReactTestUtils.Simulate.keyDown(timeInput.input, {
     keyCode: up ? 38 : 40,

--- a/test/lib/renderTimeInput.js
+++ b/test/lib/renderTimeInput.js
@@ -2,13 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TimeInput from '../../src/TimeInput';
 
-export default (value, el, omitOnChange) => {
-  var timeInput = render(value);
+export default (value, el, omitOnChange, step) => {
+  var timeInput = render(value, step);
   timeInput.input.focus();
   return timeInput;
-  function render(value) {
+  function render(value, step) {
     return ReactDOM.render(
       <TimeInput
+        step={step}
         value={value}
         onChange={!omitOnChange ? render : undefined}
         defaultValue="00:00:00:000"


### PR DESCRIPTION
So the idea here is that i want to "add" or "take a way" a specific amount of minutes, basically add a jump steps
For example: add 15 mins every time i press on "arrow up" key when i have the caret on minutes group
```jsx
const value = "12:00 AM"
<TimeInput value={value} step={15} onChange={onChange}/>
// expected the output when "key up" pressed
// while the caret is positioned in minutes group to be: "12:15 AM"
```